### PR TITLE
CMakeLists: Check for gettext before invoking PluginLocalization.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,15 +181,14 @@ if (NOT ${BUILD_TYPE} STREQUAL "flatpak")
   # Build package as required (flatpak already dealt with).
   #
   include(PluginCompiler)
-  include(PluginLocalization)
   include(PluginInstall)
   include(PluginPackage)
-
   if (QT_ANDROID)
     include(libs/AndroidLibs.cmake)
   else ()
     include(PluginLibs)
   endif ()
+  include(PluginLocalization)
 
   include_directories(BEFORE ${CMAKE_BINARY_DIR}/include)
   include_directories(${CMAKE_SOURCE_DIR}/src)

--- a/libs/AndroidLibs.cmake
+++ b/libs/AndroidLibs.cmake
@@ -4,6 +4,8 @@
 #
 cmake_minimum_required(VERSION 3.1)
 
+find_package(Gettext REQUIRED)
+
 set(Qt_Build  "build_arm64/qtbase"
   CACHE STRING "Base directory for QT build"
 )


### PR DESCRIPTION
As heading says: PluginLocalization uses variables set up by PluginLibs. Change the order how these files are included in CMakeLists to respect this.

While on it, ensure that also AndroidLibs sets up the gettext variables used by PluginLocalization.

Looking at the [build logs](https://app.circleci.com/pipelines/github/leamas/o-charts_pi/85/workflows/5daec895-e599-415e-8584-a571d1e05b17), all builds seems to produce .mo files