### PR TITLE
ci: flatpak: Update TLS certificates before use.

### DIFF
--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -10,6 +10,9 @@ echo "Using manifest file: $MANIFEST"
 set -x
 
 sudo apt update
+
+# Avoid using outdated certificates causing "Unacceptable TLS certificate"
+# errors.
 sudo apt install --reinstall  ca-certificates
 
 

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -10,6 +10,7 @@ echo "Using manifest file: $MANIFEST"
 set -x
 
 sudo apt update
+sudo apt install --reinstall  ca-certificates
 
 
 # Install flatpak and flatpak-builder


### PR DESCRIPTION
As heading says: Update otherwise outdated certificates in Ubuntu 20.04  before use. 

An example of the horrors using a not updated OS... 

Circle ci build logs [here](https://app.circleci.com/pipelines/github/leamas/o-charts_pi/89/workflows/5822c451-d47c-4170-9ebe-aa2fef8df062) The Android failure seems unrelated.

