### PR TITLE
Add fedora to the list of Linux distributions for metadata generation

### DIFF
--- a/cmake/Metadata.cmake
+++ b/cmake/Metadata.cmake
@@ -161,7 +161,7 @@ endif ()
 # pkg_target_arch: os + optional -arch suffix. See: Opencpn bug #2003
 if ("${BUILD_TYPE}" STREQUAL "flatpak")
   set(pkg_target_arch "flatpak-${ARCH}")
-elseif ("${plugin_target}" MATCHES "ubuntu|raspbian|debian|mingw")
+elseif ("${plugin_target}" MATCHES "ubuntu|raspbian|debian|mingw|fedora")
   set(pkg_target_arch "${plugin_target}-${ARCH}")
 else ()
   set(pkg_target_arch "${plugin_target}")


### PR DESCRIPTION
Allows generation of correct target name including architecture in metadata XML (`eg. fedora-x86_64` instead of `fedora`) to make the resulting tarball importable by the plugin manager.