### PR TITLE
Disable polygon and line smoothing to prevent OpenGL bugs

### DIFF
--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -501,8 +501,8 @@ s52plib::s52plib( const wxString& PLib, bool b_forceLegacy )
     m_useFBO = false;
     m_useVBO = false;
     m_TextureFormat = -1;
-    SetGLPolygonSmoothing( true );
-    SetGLLineSmoothing( true );
+    SetGLPolygonSmoothing( false );
+    SetGLLineSmoothing( false );
 
     m_display_size_mm = 300;
     m_displayScale = 1.0;


### PR DESCRIPTION
At least https://github.com/OpenCPN/OpenCPN/issues/2826 was reproducible for me with esSENC charts.
It actually seems that only disabling polygon smoothing resolved the problem, line smoothing disabled for consistency with the core.