### PR TITLE
flatpak: manifest: Update iproute2 to latest version

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
@@ -42,8 +42,8 @@ modules:
   - name: iproute2
     sources:
       - type: archive
-        url: https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-5.7.0.tar.xz
-        sha256: 725dc7ba94aae54c6f8d4223ca055d9fb4fe89d6994b1c03bfb4411c4dd10f21
+        url: https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-6.9.0.tar.xz
+        sha256: 2f643d09ea11a4a2a043c92e2b469b5f73228cbf241ae806760296ed0ec413d0
     no-autogen: true
     buildsystem: autotools
     make-args:


### PR DESCRIPTION
Required to avoid FTBFS on 24.08 runtime.