### PR TITLE
ci: flatpak: 22.08: Handle missing flatpak glew dependency.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,20 +168,6 @@ jobs:
     environment:
       - OCPN_TARGET: flatpak
       - CMAKE_BUILD_PARALLEL_LEVEL: 2
-      - BRANCH: stable
-    parameters:
-      cache-key:
-        type: string
-        # Update the last part, here v2, to invalidate cache
-        default: "fp-x86-20-v2"
-    <<: *flatpak-steps
-
-  build-flatpak-x86-2408:
-    machine:
-      image: ubuntu-2204:current
-    environment:
-      - OCPN_TARGET: flatpak
-      - CMAKE_BUILD_PARALLEL_LEVEL: 2
       - BRANCH: beta
     parameters:
       cache-key:
@@ -190,6 +176,34 @@ jobs:
         default: "fp-x86-20-v2"
     <<: *flatpak-steps
 
+  build-flatpak-arm64-2208:
+    machine:
+      image: ubuntu-2204:current
+    resource_class: arm.medium
+    environment:
+      - OCPN_TARGET: flatpak-arm64
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+      - BRANCH: stable
+    parameters:
+      cache-key:
+        type: string
+        # Update the last part, here v2, to invalidate cache
+        default: "fp-arm20-v2"
+    <<: *flatpak-steps
+
+  build-flatpak-x86-2208:
+    machine:
+      image: ubuntu-2204:current
+    environment:
+      - OCPN_TARGET: flatpak
+      - CMAKE_BUILD_PARALLEL_LEVEL: 2
+      - BRANCH: stable
+    parameters:
+      cache-key:
+        type: string
+        # Update the last part, here v2, to invalidate cache
+        default: "fp-x86-20-v2"
+    <<: *flatpak-steps
 
   build-macos:
     macos:
@@ -258,7 +272,10 @@ workflows:
       - build-flatpak-x86:
           <<: *std-filters
 
-      - build-flatpak-x86-2408:
+      - build-flatpak-arm64-2208:
+          <<: *std-filters
+
+      - build-flatpak-x86-2208:
           <<: *std-filters
 
       - build-macos:

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -80,6 +80,11 @@ manifest=$(ls ../flatpak/org.opencpn.OpenCPN.Plugin*yaml)
 sed -i  '/^runtime-version/s/:.*/:'" ${BRANCH:-stable}/"  $manifest
 sed -i  '/^sdk:/s|//.*|//'"${SDK:-22.08}|"  $manifest
 
+if [[ "$SDK" = 22.08 ]]; then
+  # For 22.08 builds, add a local glew dependency
+  patch -p1 $manifest < $HOME/project/ci/flatpak-22.08-glew.patch
+fi
+
 flatpak install --user -y --or-update --noninteractive \
     ${FLATHUB_REPO:-flathub}  org.opencpn.OpenCPN
 

--- a/ci/flatpak-22.08-glew.patch
+++ b/ci/flatpak-22.08-glew.patch
@@ -1,0 +1,42 @@
+From 5e9034c259f397ccf5e2f393bb3d927da4ae5315 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Wed, 14 May 2025 08:33:38 +0200
+Subject: [PATCH] flatpak: manifest: Add a local glew dependency
+
+---
+ .../org.opencpn.OpenCPN.Plugin.o-charts.yaml  | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml b/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
+index 4aa534b4..9c320762 100644
+--- a/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
++++ b/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
+@@ -36,6 +36,25 @@ modules:
+ 
+     - @include opencpn-libs/flatpak/libusb.yaml
+ 
++    - name: glew
++      no-autogen: true
++      make-args:
++        - GLEW_PREFIX=/app/extensions/o-charts_pi
++        - GLEW_DEST=/app/extensions/o-charts_pi
++        - LIBDIR=/app/extensions/o-charts_pi/lib
++      make-install-args:
++        - GLEW_PREFIX=/app/extensions/o-charts_pi
++        - GLEW_DEST=/app/extensions/o-charts_pi
++        - LIBDIR=/app/extensions/o-charts_pi/lib
++      sources:
++        - type: archive
++          url: https://downloads.sourceforge.net/project/glew/glew/2.1.0/glew-2.1.0.tgz
++          sha256: 04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95
++      cleanup:
++        - /include"
++        - /lib/pkgconfig"
++        - /lib/*.a"
++
+     - name: libusb-compat-0.1
+       config-opts:
+         - --disable-static
+-- 
+2.49.0
+

--- a/libs/geoprim/CMakeLists.txt
+++ b/libs/geoprim/CMakeLists.txt
@@ -40,15 +40,3 @@ target_link_libraries(GEOPRIM PRIVATE glew2::glew2)
 if(QT_ANDROID)
     target_include_directories(GEOPRIM PRIVATE ../../includeAndroid)
 endif(QT_ANDROID)
-
-find_package(OpenGL)
-if (OPENGL_FOUND)
-    target_include_directories(GEOPRIM PRIVATE ${OPENGL_INCLUDE_DIR})
-
-    message(STATUS "Found OpenGL....")
-    message(STATUS "    GL Lib: " ${OPENGL_LIBRARIES})
-    message(STATUS "    GL Include: " ${OPENGL_INCLUDE_DIR})
-
-    target_link_libraries(GEOPRIM PRIVATE ${OPENGL_LIBRARIES} )
-endif (OPENGL_FOUND)
-


### PR DESCRIPTION
22.08  builds are done against OpenCPN  5.10 which does not have the  flatpak glew dependency. Thus, for these builds add a local glew dependency to o-charts.

This is  fragile fix using a patch which will break for most manifest updates. Sigh. The sooner we git rid of 22.08, the better.
