### PR TITLE
Handle libusb now available in 25.08 runtime

### DIFF
--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -93,10 +93,13 @@ manifest=$(ls ../flatpak/org.opencpn.OpenCPN.Plugin*yaml)
 sed -i  '/^runtime-version/s/:.*/:'" ${FLATHUB_BRANCH:-stable}/"  $manifest
 sed -i  '/^sdk:/s|//.*|//'"${SDK:-24.08}|"  $manifest
 
-if (( "$BRANCH" >= 2508 )); then
-    # From 25.08 the runtime contains libusb. If manifest has added this,
-    # remove it.
-    sed -i '/libusb/,/name:/d' $manifest
+if (( "$BRANCH" < 2508 )); then
+    # Older runtimes contains no libusb, so use the full usb dependency
+    # instead of libusb-compat-0.1
+    sed -i '/libusb/s/libusb-compat-0.1.yaml/libusb.yaml/' $manifest
+
+    # temporary fix for local libusb-compat-0.1.yaml in libs/flatpak
+    sed -i '/libusb/s/include libs/include opencpn-libs/' $manifest
 fi
 
 flatpak install --user -y --or-update --noninteractive \

--- a/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
@@ -14,7 +14,7 @@ id: org.opencpn.OpenCPN.Plugin.@plugin_name
 
 runtime: org.opencpn.OpenCPN
 runtime-version: stable
-sdk: org.freedesktop.Sdk//24.08
+sdk: org.freedesktop.Sdk//25.08
 build-extension: true
 separate-locales: false
 appstream-compose: false
@@ -27,7 +27,7 @@ finish-args:
 modules:
     - @include opencpn-libs/flatpak/glu.yaml
 
-    - @include opencpn-libs/flatpak/libusb.yaml
+    - @include libs/flatpak/libusb-compat-0.1.yaml
 
     - name: glew
       no-autogen: true
@@ -47,22 +47,6 @@ modules:
         - /include"
         - /lib/pkgconfig"
         - /lib/*.a"
-
-    - name: libusb-compat-0.1
-      config-opts:
-        - --disable-static
-        - --prefix=/app/extensions/o-charts_pi
-      build-options:
-        env:
-          PKG_CONFIG_PATH: /app/extensions/o-charts_pi/lib/pkgconfig
-      sources:
-        - type: git
-          url: https://github.com/libusb/libusb-compat-0.1.git
-          tag: v0.1.7
-      cleanup:
-        - /lib/*.la
-        - /lib/pkgconfig
-        - /include
 
     - name: iproute2
       sources:

--- a/libs/flatpak/libusb-compat-0.1.yaml
+++ b/libs/flatpak/libusb-compat-0.1.yaml
@@ -1,0 +1,12 @@
+- name: libusb-compat-0.1
+  config-opts:
+     - --disable-static
+     - --disable-udev
+     - --prefix=/app/extensions/@app_id
+  sources:
+     - type: archive
+       url: https://github.com/libusb/libusb-compat-0.1/archive/refs/tags/v0.1.8.tar.gz
+       sha256: 73f8023b91a4359781c6f1046ae84156e06816aa5c2916ebd76f353d41e0c685
+  cleanup: ["/include", "/lib/*.a", "/lib/*.la", "/lib/pkgconfig"]
+
+


### PR DESCRIPTION
From 25.08 the runtime contains libusb, but not the libusb-0.1 ABI we require. 

On 25.08+ buildsremove current libusb dependency and add libusb-compat-0.1 which provides  and 0.1 interface on top of libusb-1.0.

On runtime < 25.08 use current libusb dependency and remove libusb-compat-0.1

Set the default, local build to use runtime 25.08 which uses libusb-compat-0.1 only.