### PR TITLE
flatpak: Use alternative autoconf-archive mirror

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.o-charts.yaml
@@ -37,7 +37,7 @@ modules:
         - DESTDIR=/app/extensions/o-charts_pi
       sources:
         - type: archive
-          url: http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2024.10.16.tar.xz
+          url: https://mirrors.dotsrc.org/gnu/autoconf-archive/autoconf-archive-2024.10.16.tar.xz
           sha256: 7bcd5d001916f3a50ed7436f4f700e3d2b1bade3ed803219c592d62502a57363
 
     - name: libmnl


### PR DESCRIPTION
The current autoconf-archive mirror is not that stable with intermittent 502 errors. Try a new mirror for hopefully better results